### PR TITLE
central: require license to run

### DIFF
--- a/bin/sl-central-install.js
+++ b/bin/sl-central-install.js
@@ -42,6 +42,7 @@ function install(argv, callback) {
       'U:(upstart)',
       's(systemd)',
       'a:(http-auth)',
+      'L:(license)',
     ].join(''),
     argv);
 
@@ -59,6 +60,7 @@ function install(argv, callback) {
     centralSeedEnv: {},
   };
 
+  var license;
   var option;
   while ((option = parser.getopt()) !== undefined) {
     switch (option.option) {
@@ -98,6 +100,9 @@ function install(argv, callback) {
       case 'a':
         jobConfig.env.STRONGLOOP_PM_HTTP_AUTH = option.optarg;
         break;
+      case 'L':
+        license = option.optarg;
+        break;
       default:
         install.error('Invalid usage (near option \'%s\'), try `%s --help`.',
           option.optopt, $0);
@@ -109,6 +114,14 @@ function install(argv, callback) {
     install.error('Invalid usage (extra arguments), try `%s --help`.', $0);
     return callback(Error('usage'));
   }
+
+  if (!license) {
+    license = require('strongloop-license')('mesh:central', 'EXIT');
+    if (!license) return;
+    license = license.key;
+  }
+
+  jobConfig.env.STRONGLOOP_LICENSE = license;
 
   if (jobConfig.centralPort < 1) {
     install.error('Invalid port specified, try `%s --help`.', $0);

--- a/bin/sl-central-install.txt
+++ b/bin/sl-central-install.txt
@@ -19,6 +19,11 @@ Options:
                       the specified credentials for every request sent to the
                       REST API where CREDS is given in the form of
                       `<user>:<pass>`.
+  -L,--license LIC    Install with license LIC (default is the user's license).
+
+Note that Central requires a license in order to run. If you have questions
+about how to find your license or StrongLoop licensing please contact
+sales@strongloop.com.
 
 OS Service support:
 

--- a/bin/sl-central.js
+++ b/bin/sl-central.js
@@ -4,11 +4,21 @@
 
 var Parser = require('posix-getopt').BasicParser;
 var Server = require('../server/server');
+var license = require('strongloop-license');
 var mkdirp = require('mkdirp').sync;
 var path = require('path');
 var fs = require('fs');
 var versionApi = require('strong-mesh-models/package.json').version;
 var versionCentral = require('../package.json').version;
+
+if (!license('mesh:central', licenseCheck))
+  return;
+
+// We only want the default message when unlicensed, be silent on success.
+function licenseCheck(err, req, res) {
+  if (err || !res)
+    require('strongloop-license').EXIT(err, req, res);
+}
 
 function printHelp($0, prn) {
   var USAGE = fs.readFileSync(require.resolve('./sl-central.txt'), 'utf-8')

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "strong-spawn-npm": "^1.0.0",
     "strong-tunnel": "^1.1.0",
     "strong-url-defaults": "^1.0.0",
+    "strongloop-license": "^1.4.0",
     "tar": "^2.1.1"
   }
 }


### PR DESCRIPTION
After this change, sl-central exits with no license:

```
% sl-central
## mesh:central licensing missing or invalid. Please verify your licenses in the Licenses page by running StrongLoop Arc by typing "slc arc --licenses" . If you have questions about your license or StrongLoop licensing please contact sales@strongloop.com.
##  Terminating process.
```

A couple questions:
1. do those instructions make sense for sl-central?
2. `mesh:central` is almost certainly NOT the name of the license - what should it be? @chandadharap ?
3. sl-central-install can take a license with `-L,--license`, but it will use `$STRONGLOOP_LICENSE` as a default... perhaps it should also pull the license out of ~/.strongloop/license if its there? *note well* that the install sl-central won't have access to the user's environment and files, so if the user who is installing has a license somewhere, it needs to be explicitly put in the systemd startup file
4. this will kill our CI, unless there is a universal license that matches all features, I think there is, but it doesn't match `mesh:central`, at least my STRONGLOOP_LICENSE doesn't, and I thought it was pretty universal.

For "3.", @rmg, maybe I can get access to the concatenated env variable from about https://github.com/strongloop/strongloop-license/blob/master/index.js#L49 ?

connected to strongloop-internal/scrum-nodeops#783
depends on https://github.com/strongloop/strongloop-license/pull/12