### PR TITLE
Fix tap tests

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -18,6 +18,7 @@ function createCentralAndTest(title, testFn) {
         centralUri.port = centralApp.port();
 
         testFn(t, centralApp, centralUri);
+        t.end();
       });
       centralApp.start();
     });

--- a/test/test-executor-driver.js
+++ b/test/test-executor-driver.js
@@ -194,7 +194,7 @@ function runTest(t, baseDir, artifactDir) {
       var artifactFileStream = fs.createWriteStream(dumpFile);
       driver.getDriverArtifact(
         'i1', 'commithash', mockRequest, artifactFileStream);
-      artifactFileStream.on('end', function() {
+      artifactFileStream.on('finish', function() {
         var f1 = fs.statSync(expectedArtifact);
         var f2 = fs.statSync(dumpFile);
         tt.equal(f1.size, f2.size);


### PR DESCRIPTION
Restructure's a couple tests to be a little less deeply asynchronously nested, and fixed one actual bug in the executor-driver tests that was discovered by the updated version of tap.